### PR TITLE
Implement state machine for intake servos with independent wheel and …

### DIFF
--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/MainTeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/MainTeleOp.java
@@ -4,6 +4,7 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 import org.firstinspires.ftc.teamcode.common.subsystems.IntakeSubsystem;
+import org.firstinspires.ftc.teamcode.common.subsystems.IntakeSubsystem.SlideState;
 import org.firstinspires.ftc.teamcode.common.subsystems.MecanumDriveSubsystem;
 
 @TeleOp(name = "MainTeleOp 11940", group = "TeleOp")
@@ -68,8 +69,9 @@ public class MainTeleOp extends LinearOpMode {
         telemetry.addLine("D-pad Up/Down - Speed Adjust");
         telemetry.addLine("D-pad Left/Right - Sensitivity");
         telemetry.addLine();
-        telemetry.addLine("Right Bumper - Intake");
-        telemetry.addLine("Left Bumper - Eject");
+        telemetry.addLine("Right Bumper - Intake Wheels");
+        telemetry.addLine("Left Bumper - Eject Wheels");
+        telemetry.addLine("Y Button (Hold) - Extend Slides");
         telemetry.addLine();
         telemetry.addLine("Options - Toggle Field/Robot Mode");
         telemetry.addLine("Share - Reset Heading (0°)");
@@ -163,12 +165,20 @@ public class MainTeleOp extends LinearOpMode {
             /* ========================================
              * DRIVER 1 - INTAKE CONTROLS
              * ======================================== */
+            // Intake wheel control (bumpers)
             if (gamepad1.right_bumper) {
                 intake.intakeArtifact();
             } else if (gamepad1.left_bumper) {
                 intake.ejectArtifact();
             } else {
                 intake.stop();
+            }
+
+            // Intake slide control (Y button - hold to extend, release to retract)
+            if (gamepad1.y) {
+                intake.setSlideState(SlideState.OUT);
+            } else {
+                intake.setSlideState(SlideState.IN);
             }
 
             /* ========================================
@@ -213,8 +223,10 @@ public class MainTeleOp extends LinearOpMode {
             // Intake telemetry
             telemetry.addLine();
             telemetry.addLine("=== INTAKE ===");
-            telemetry.addData("Speed", "%.2f", intake.getSpeed());
-            telemetry.addData("Position", "%.3f", intake.getPosition());
+            telemetry.addData("Wheel State", intake.getWheelStateString());
+            telemetry.addData("Wheel Speed", "%.2f", intake.getSpeed());
+            telemetry.addData("Slide State", intake.getSlideStateString());
+            telemetry.addData("Slide Position", "%.3f", intake.getSlidePosition());
 
             // Shooter telemetry
 //            telemetry.addLine();

--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
@@ -5,6 +5,7 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.teamcode.common.subsystems.MecanumDriveSubsystem;
 import org.firstinspires.ftc.teamcode.common.subsystems.MecanumDriveSubsystem.DriveState;
 import org.firstinspires.ftc.teamcode.common.subsystems.IntakeSubsystem;
+import org.firstinspires.ftc.teamcode.common.subsystems.IntakeSubsystem.SlideState;
 
 @TeleOp(name = "StateMachine TeleOp", group = "TeleOp")
 public class StateMachineTeleOp extends LinearOpMode {
@@ -59,14 +60,16 @@ public class StateMachineTeleOp extends LinearOpMode {
         telemetry.addData("Status", "Ready to start!");
         telemetry.addLine();
         telemetry.addLine("Controls:");
-        telemetry.addLine("  Left Stick   - Strafe");
-        telemetry.addLine("  Right Stick  - Rotate");
-        telemetry.addLine("  Right Bumper - Intake");
-        telemetry.addLine("  Left Bumper  - Eject");
-        telemetry.addLine("  X Button     - Toggle Field-Centric");
-        telemetry.addLine("  Y Button     - Toggle Precision Mode");
-        telemetry.addLine("  B Button     - Toggle Turbo Mode");
-        telemetry.addLine("  Options      - Reset Heading");
+        telemetry.addLine("  Left Stick      - Strafe");
+        telemetry.addLine("  Right Stick     - Rotate");
+        telemetry.addLine("  Right Bumper    - Intake Wheels");
+        telemetry.addLine("  Left Bumper     - Eject Wheels");
+        telemetry.addLine("  Right Trigger   - Extend Slides (Hold)");
+        telemetry.addLine("  X Button        - Toggle Field-Centric");
+        telemetry.addLine("  Y Button        - Toggle Precision Mode");
+        telemetry.addLine("  B Button        - Toggle Turbo Mode");
+        telemetry.addLine("  A Button        - Emergency Stop");
+        telemetry.addLine("  Options         - Reset Heading");
         telemetry.addLine("  D-Pad Up/Down   - Adjust Speed");
         telemetry.addLine("  D-Pad Left/Right - Adjust Sensitivity");
         telemetry.update();
@@ -196,17 +199,22 @@ public class StateMachineTeleOp extends LinearOpMode {
      * INTAKE CONTROL HANDLER
      * ======================================== */
     private void handleIntakeControls() {
-        // Right Bumper - Intake
+        // Intake wheel control (bumpers)
         if (gamepad1.right_bumper) {
             intake.intakeArtifact();
         }
-        // Left Bumper - Eject
         else if (gamepad1.left_bumper) {
             intake.ejectArtifact();
         }
-        // No bumpers pressed - Stop
         else {
             intake.stop();
+        }
+
+        // Intake slide control (right trigger - hold to extend, release to retract)
+        if (gamepad1.right_trigger > 0.5) {
+            intake.setSlideState(SlideState.OUT);
+        } else {
+            intake.setSlideState(SlideState.IN);
         }
     }
 
@@ -233,14 +241,10 @@ public class StateMachineTeleOp extends LinearOpMode {
 
         telemetry.addLine();
         telemetry.addLine("=== INTAKE SUBSYSTEM ===");
-        telemetry.addData("Speed", "%.2f", intake.getSpeed());
-        String intakeState = "STOPPED";
-        if (gamepad1.right_bumper) {
-            intakeState = "INTAKING";
-        } else if (gamepad1.left_bumper) {
-            intakeState = "EJECTING";
-        }
-        telemetry.addData("State", intakeState);
+        telemetry.addData("Wheel State", intake.getWheelStateString());
+        telemetry.addData("Wheel Speed", "%.2f", intake.getSpeed());
+        telemetry.addData("Slide State", intake.getSlideStateString());
+        telemetry.addData("Slide Position", "%.3f", intake.getSlidePosition());
 
         telemetry.addLine();
         telemetry.addLine("=== CONFIGURATION ===");


### PR DESCRIPTION
…slide control

This commit adds comprehensive state machine logic for the intake subsystem:

**IntakeSubsystem Changes:**
- Added WheelState enum (IDLE, INTAKING, EJECTING) for intake wheel control
- Added SlideState enum (IN, OUT) for intake slide position control
- Enabled right intake wheel servo with reversed direction for mirrored operation
- Enabled right intake slide servo with reversed direction for mirrored operation
- Implemented proper slide position control (fixed FIXME comments)
- Added state management methods: setWheelState(), setSlideState(), getters
- Maintained backward compatibility with existing teleop code
- Left side servos now run opposite to right side servos as required

**MainTeleOp Changes:**
- Added Y button control for intake slides (hold to extend, release to retract)
- Updated telemetry to show wheel state, slide state, and positions
- Updated controls documentation

**StateMachineTeleOp Changes:**
- Added right trigger control for intake slides (hold to extend, release)
- Updated telemetry to show wheel state, slide state, and positions
- Updated controls documentation

**Hardware Requirements:**
Robot must have these four servos configured in FTC Robot Controller:
- intakeServoLeft (continuous rotation wheel)
- intakeServoRight (continuous rotation wheel)
- intakeSlideLeft (position servo)
- intakeSlideRight (position servo)

For testing purposes, wheels and slides are independently controlled. Future enhancement: Auto-extend slides when intaking, retract when idle/ejecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before issuing a pull request, please see the contributing page.
