### PR TITLE
Implement automatic slide control with intake servos

### DIFF
--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/MainTeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/MainTeleOp.java
@@ -71,7 +71,7 @@ public class MainTeleOp extends LinearOpMode {
         telemetry.addLine();
         telemetry.addLine("Right Bumper - Intake Wheels");
         telemetry.addLine("Left Bumper - Eject Wheels");
-        telemetry.addLine("Y Button (Hold) - Extend Slides");
+        telemetry.addLine("(Slides auto-extend/retract)");
         telemetry.addLine();
         telemetry.addLine("Options - Toggle Field/Robot Mode");
         telemetry.addLine("Share - Reset Heading (0°)");
@@ -88,6 +88,11 @@ public class MainTeleOp extends LinearOpMode {
          * MAIN CONTROL LOOP
          * ======================================== */
         while (opModeIsActive()) {
+
+            /* ========================================
+             * SUBSYSTEM PERIODIC UPDATES
+             * ======================================== */
+            intake.periodic(); // Handle automatic slide control
 
             /* ========================================
              * DRIVER 1 - DRIVE CONTROLS
@@ -166,6 +171,7 @@ public class MainTeleOp extends LinearOpMode {
              * DRIVER 1 - INTAKE CONTROLS
              * ======================================== */
             // Intake wheel control (bumpers)
+            // Slides automatically extend when intake is running and retract 300ms after stopping
             if (gamepad1.right_bumper) {
                 intake.intakeArtifact();
             } else if (gamepad1.left_bumper) {
@@ -174,12 +180,14 @@ public class MainTeleOp extends LinearOpMode {
                 intake.stop();
             }
 
-            // Intake slide control (Y button - hold to extend, release to retract)
-            if (gamepad1.y) {
-                intake.setSlideState(SlideState.OUT);
-            } else {
-                intake.setSlideState(SlideState.IN);
-            }
+            // Manual slide override (Y button - disabled by default, slides are automatic)
+            // Uncomment below to enable manual slide control:
+            // if (gamepad1.y) {
+            //     intake.disableAutoSlideControl();
+            //     intake.setSlideState(SlideState.OUT);
+            // } else {
+            //     intake.setSlideState(SlideState.IN);
+            // }
 
             /* ========================================
              * DRIVER 1 - SHOOTER CONTROLS
@@ -227,6 +235,7 @@ public class MainTeleOp extends LinearOpMode {
             telemetry.addData("Wheel Speed", "%.2f", intake.getSpeed());
             telemetry.addData("Slide State", intake.getSlideStateString());
             telemetry.addData("Slide Position", "%.3f", intake.getSlidePosition());
+            telemetry.addData("Auto Slide Control", intake.isAutoSlideControlEnabled() ? "ENABLED" : "DISABLED");
 
             // Shooter telemetry
 //            telemetry.addLine();

--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
@@ -64,7 +64,7 @@ public class StateMachineTeleOp extends LinearOpMode {
         telemetry.addLine("  Right Stick     - Rotate");
         telemetry.addLine("  Right Bumper    - Intake Wheels");
         telemetry.addLine("  Left Bumper     - Eject Wheels");
-        telemetry.addLine("  Right Trigger   - Extend Slides (Hold)");
+        telemetry.addLine("  (Slides auto-extend/retract)");
         telemetry.addLine("  X Button        - Toggle Field-Centric");
         telemetry.addLine("  Y Button        - Toggle Precision Mode");
         telemetry.addLine("  B Button        - Toggle Turbo Mode");
@@ -83,6 +83,9 @@ public class StateMachineTeleOp extends LinearOpMode {
          * MAIN LOOP
          * ======================================== */
         while (opModeIsActive()) {
+
+            // Update subsystems
+            intake.periodic(); // Handle automatic slide control
 
             // Handle state transitions
             handleStateTransitions();
@@ -200,6 +203,7 @@ public class StateMachineTeleOp extends LinearOpMode {
      * ======================================== */
     private void handleIntakeControls() {
         // Intake wheel control (bumpers)
+        // Slides automatically extend when intake is running and retract 300ms after stopping
         if (gamepad1.right_bumper) {
             intake.intakeArtifact();
         }
@@ -210,12 +214,14 @@ public class StateMachineTeleOp extends LinearOpMode {
             intake.stop();
         }
 
-        // Intake slide control (right trigger - hold to extend, release to retract)
-        if (gamepad1.right_trigger > 0.5) {
-            intake.setSlideState(SlideState.OUT);
-        } else {
-            intake.setSlideState(SlideState.IN);
-        }
+        // Manual slide override (right trigger - disabled by default, slides are automatic)
+        // Uncomment below to enable manual slide control:
+        // if (gamepad1.right_trigger > 0.5) {
+        //     intake.disableAutoSlideControl();
+        //     intake.setSlideState(SlideState.OUT);
+        // } else {
+        //     intake.setSlideState(SlideState.IN);
+        // }
     }
 
     /* ========================================
@@ -245,6 +251,7 @@ public class StateMachineTeleOp extends LinearOpMode {
         telemetry.addData("Wheel Speed", "%.2f", intake.getSpeed());
         telemetry.addData("Slide State", intake.getSlideStateString());
         telemetry.addData("Slide Position", "%.3f", intake.getSlidePosition());
+        telemetry.addData("Auto Slide Control", intake.isAutoSlideControlEnabled() ? "ENABLED" : "DISABLED");
 
         telemetry.addLine();
         telemetry.addLine("=== CONFIGURATION ===");


### PR DESCRIPTION
When the left or right intake bumper buttons are engaged, the slides now automatically extend. When the buttons are released, the slides retract after a 300ms delay. This provides a more streamlined intake operation.

Changes:
- Added automatic slide control to IntakeSubsystem with configurable 300ms delay
- Slides extend immediately when intake wheels are active (INTAKING or EJECTING)
- Slides retract automatically 300ms after intake wheels become idle
- Added enable/disable methods for automatic slide control
- Updated MainTeleOp and StateMachineTeleOp to use automatic slide control
- Removed manual Y button and right trigger slide controls (commented out for optional override)
- Updated telemetry to show auto slide control status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before issuing a pull request, please see the contributing page.
