### PR TITLE
Reverse slide/wheel timing: slides retract immediately, wheels run fo…

### DIFF
--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/MainTeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/MainTeleOp.java
@@ -171,7 +171,8 @@ public class MainTeleOp extends LinearOpMode {
              * DRIVER 1 - INTAKE CONTROLS
              * ======================================== */
             // Intake wheel control (bumpers)
-            // Slides automatically extend when intake is running and retract 300ms after stopping
+            // Slides automatically extend when intake is running and retract immediately when stopping
+            // Wheels continue running for 300ms after slides retract
             if (gamepad1.right_bumper) {
                 intake.intakeArtifact();
             } else if (gamepad1.left_bumper) {

--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
@@ -203,7 +203,8 @@ public class StateMachineTeleOp extends LinearOpMode {
      * ======================================== */
     private void handleIntakeControls() {
         // Intake wheel control (bumpers)
-        // Slides automatically extend when intake is running and retract 300ms after stopping
+        // Slides automatically extend when intake is running and retract immediately when stopping
+        // Wheels continue running for 300ms after slides retract
         if (gamepad1.right_bumper) {
             intake.intakeArtifact();
         }


### PR DESCRIPTION
…r 300ms

Changed the automatic slide control timing behavior:
- Previously: Wheels stop immediately, slides retract after 300ms delay
- Now: Slides retract immediately, wheels continue running for 300ms

This allows the wheels to finish collecting/ejecting any artifacts in progress after the slides have retracted, providing better intake performance.

Implementation:
- Renamed SLIDE_RETRACT_DELAY_MS to WHEEL_STOP_DELAY_MS for clarity
- Added delayedWheelStop flag to track when in delayed stop mode
- Modified stop() to immediately retract slides and enter delayed mode
- Updated periodic() to handle delayed wheel stopping after 300ms
- Added cancellation of delayed stop when intake/eject buttons pressed
- Updated comments in both teleop files to reflect new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before issuing a pull request, please see the contributing page.
