### PR TITLE
Change gamepad2 D-pad to increment/decrement velocity by 100 RPM

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/subsystems/ShooterSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/subsystems/ShooterSubsystem.java
@@ -49,6 +49,7 @@ public class ShooterSubsystem {
     // State tracking
     private FlywheelState currentState = FlywheelState.MEDIUM_RANGE; // Default to medium range
     private double targetVelocity = 0.0;
+    private int targetRPM = 0; // Track current target RPM for manual adjustments
 
     // Hardware configuration names
     private static final String TURRET_SERVO_NAME = "turretServo";
@@ -212,6 +213,7 @@ public class ShooterSubsystem {
      * Stop the flywheel
      */
     public void stopFlywheel() {
+        targetRPM = 0;
         targetVelocity = 0.0;
         flywheelMotor.setVelocity(0.0);
     }
@@ -256,6 +258,7 @@ public class ShooterSubsystem {
      */
     public void setFlywheelState(FlywheelState state) {
         currentState = state;
+        targetRPM = state.getRPM();
         targetVelocity = state.getVelocity();
         flywheelMotor.setVelocity(targetVelocity);
     }
@@ -295,7 +298,34 @@ public class ShooterSubsystem {
      * @return Target RPM
      */
     public int getTargetRPM() {
-        return currentState.getRPM();
+        return targetRPM;
+    }
+
+    /**
+     * Set flywheel to specific RPM
+     * @param rpm Target RPM (will be clamped to valid range)
+     */
+    public void setFlywheelRPM(int rpm) {
+        // Clamp RPM to reasonable range (0 to 6000 max motor speed)
+        targetRPM = Math.max(0, Math.min(6000, rpm));
+        targetVelocity = (targetRPM / 60.0) * 28.0; // Convert RPM to ticks per second
+        flywheelMotor.setVelocity(targetVelocity);
+    }
+
+    /**
+     * Increment flywheel RPM by specified amount
+     * @param increment Amount to increase RPM
+     */
+    public void incrementFlywheelRPM(int increment) {
+        setFlywheelRPM(targetRPM + increment);
+    }
+
+    /**
+     * Decrement flywheel RPM by specified amount
+     * @param decrement Amount to decrease RPM
+     */
+    public void decrementFlywheelRPM(int decrement) {
+        setFlywheelRPM(targetRPM - decrement);
     }
 
 

--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/StateMachineTeleOp.java
@@ -39,8 +39,8 @@ public class StateMachineTeleOp extends LinearOpMode {
     private boolean lastGP2_YState = false;         // Hood servo up
     private boolean lastGP2_AState = false;         // Toggle flywheel testing
     private boolean lastGP2_BState = false;         // Cycle range states
-    private boolean lastGP2_DpadUpState = false;    // Increase shooter power
-    private boolean lastGP2_DpadDownState = false;  // Decrease shooter power
+    private boolean lastGP2_DpadUpState = false;    // Increase shooter RPM
+    private boolean lastGP2_DpadDownState = false;  // Decrease shooter RPM
 
     // Flywheel and index sequential control state
     private boolean flywheelRunning = false;         // Track if flywheel is running
@@ -110,7 +110,7 @@ public class StateMachineTeleOp extends LinearOpMode {
         telemetry.addLine("  B Button        - Cycle Range States (S→M→L)");
         telemetry.addLine("  X Button        - Hood Servo Down");
         telemetry.addLine("  Y Button        - Hood Servo Up");
-        telemetry.addLine("  D-Pad Up/Down   - Adjust Shooter Power");
+        telemetry.addLine("  D-Pad Up/Down   - Adjust Shooter RPM (±100)");
         telemetry.update();
 
         waitForStart();
@@ -327,15 +327,15 @@ public class StateMachineTeleOp extends LinearOpMode {
         }
         lastGP2_BState = gamepad2.b;
 
-        // D-pad UP increases shooter power (percentage-based adjustment)
+        // D-pad UP increases shooter velocity by 100 RPM
         if (gamepad2.dpad_up && !lastGP2_DpadUpState) {
-            shooterPower = Math.min(shooterPower + SHOOTER_POWER_INCREMENT, SHOOTER_MAX_POWER);
+            shooter.incrementFlywheelRPM(100);
         }
         lastGP2_DpadUpState = gamepad2.dpad_up;
 
-        // D-pad DOWN decreases shooter power (percentage-based adjustment)
+        // D-pad DOWN decreases shooter velocity by 100 RPM
         if (gamepad2.dpad_down && !lastGP2_DpadDownState) {
-            shooterPower = Math.max(shooterPower - SHOOTER_POWER_INCREMENT, SHOOTER_MIN_POWER);
+            shooter.decrementFlywheelRPM(100);
         }
         lastGP2_DpadDownState = gamepad2.dpad_down;
 


### PR DESCRIPTION
- Add targetRPM tracking field to ShooterSubsystem
- Implement setFlywheelRPM(), incrementFlywheelRPM(), and decrementFlywheelRPM() methods
- Update StateMachineTeleOp D-pad up/down controls to use RPM increments instead of percentage-based power
- Synchronize targetRPM with state changes in setFlywheelState()
- Update telemetry to reflect RPM control (±100 RPM per press)

Before issuing a pull request, please see the contributing page.
