### PR TITLE
Refactor ShooterSubsystem: Rename ShotState to ShotPreset

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/auton/BlueLongDriveShoot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/auton/BlueLongDriveShoot.java
@@ -108,7 +108,7 @@ public class BlueLongDriveShoot extends LinearOpMode {
         // Step 4: Take shot at medium range for 5 seconds
         telemetry.addLine("Step 4: Taking shot...");
         telemetry.update();
-        takeShot(ShooterSubsystem.ShotState.MEDIUM_RANGE, SHOOTER_DURATION);
+        takeShot(ShooterSubsystem.ShotPreset.MEDIUM_RANGE, SHOOTER_DURATION);
 
         // Stop all systems
         drive.stop();
@@ -211,12 +211,12 @@ public class BlueLongDriveShoot extends LinearOpMode {
      * @param preset The shot preset (SHORT_RANGE, MEDIUM_RANGE, or LONG_RANGE)
      * @param duration Total duration in seconds
      */
-    private void takeShot(ShooterSubsystem.ShotState preset, double duration) {
+    private void takeShot(ShooterSubsystem.ShotPreset preset, double duration) {
         ElapsedTime runtime = new ElapsedTime();
         runtime.reset();
 
         // Set the shot state (flywheel + hood)
-        shooter.setShotState(preset);
+        shooter.setPreset(preset);
 
         // Wait for flywheel to reach target RPM before starting index
         boolean indexStarted = false;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/subsystems/ShooterSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/subsystems/ShooterSubsystem.java
@@ -16,7 +16,7 @@ public class ShooterSubsystem {
      * Comprehensive shooting presets with flywheel target RPM and hood position
      * Using velocity-based control for consistent speed under varying loads
      */
-    public enum ShotState {
+    public enum ShotPreset {
         LONG_RANGE(3500, 0.60),    // Long range: 2800 RPM target, high hood
         MEDIUM_RANGE(2500, 0.60),  // Medium range: 2500 RPM target, medium hood
         SHORT_RANGE(2200, 0.30);   // Short range: 2200 RPM target, low hood
@@ -24,7 +24,7 @@ public class ShooterSubsystem {
         private final int targetRPM;     // Target RPM
         private final double hoodPosition;
 
-        ShotState(int targetRPM, double hoodPosition) {
+        ShotPreset(int targetRPM, double hoodPosition) {
             this.targetRPM = targetRPM;
             this.hoodPosition = hoodPosition;
         }
@@ -50,7 +50,7 @@ public class ShooterSubsystem {
     private final DcMotorEx flywheelMotor; // goBilda motor - flywheel shooter
 
     // State tracking
-    private ShotState currentShotState = ShotState.SHORT_RANGE; // Default to short range
+    private ShotPreset currentPreset = ShotPreset.SHORT_RANGE; // Default to short range
     private double targetVelocity = 0.0; // Track current target velocity in ticks/sec
 
     // Hardware configuration names
@@ -202,21 +202,21 @@ public class ShooterSubsystem {
     }
 
     /**
-     * Set the shot state (range preset) - sets both flywheel velocity and hood position
-     * @param state The desired shot state
+     * Set the preset (range preset) - sets both flywheel velocity and hood position
+     * @param preset The desired shot preset
      */
-    public void setShotState(ShotState state) {
-        currentShotState = state;
-        setFlywheelVelocity(state.getVelocity());
-        setHoodPosition(state.getHoodPosition());
+    public void setPreset(ShotPreset preset) {
+        currentPreset = preset;
+        setFlywheelVelocity(preset.getVelocity());
+        setHoodPosition(preset.getHoodPosition());
     }
 
     /**
-     * Get the current shot state
-     * @return Current shot state
+     * Get the current preset
+     * @return Current shot preset
      */
-    public ShotState getShotState() {
-        return currentShotState;
+    public ShotPreset getPreset() {
+        return currentPreset;
     }
 
     /**
@@ -238,7 +238,7 @@ public class ShooterSubsystem {
      * @return Target RPM
      */
     public int getTargetRPM() {
-        return currentShotState.getTargetRPM();
+        return currentPreset.getTargetRPM();
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/teleop/TeleOpBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/teleop/TeleOpBase.java
@@ -318,17 +318,17 @@ public abstract class PrimeTeleOpBase extends LinearOpMode {
      * ======================================== */
     private void handleShooterControls() {
         if (gamepad2.x && !lastGP2_XState) {
-            shooter.setShotState(ShooterSubsystem.ShotState.SHORT_RANGE);
+            shooter.setPreset(ShooterSubsystem.ShotPreset.SHORT_RANGE);
         }
         lastGP2_XState = gamepad2.x;
 
         if (gamepad2.y && !lastGP2_YState) {
-            shooter.setShotState(ShooterSubsystem.ShotState.MEDIUM_RANGE);
+            shooter.setPreset(ShooterSubsystem.ShotPreset.MEDIUM_RANGE);
         }
         lastGP2_YState = gamepad2.y;
 
         if (gamepad2.b && !lastGP2_BState) {
-            shooter.setShotState(ShooterSubsystem.ShotState.LONG_RANGE);
+            shooter.setPreset(ShooterSubsystem.ShotPreset.LONG_RANGE);
         }
         lastGP2_BState = gamepad2.b;
 
@@ -358,7 +358,7 @@ public abstract class PrimeTeleOpBase extends LinearOpMode {
             flywheelRunning = true;
         } else if (gamepad2.right_bumper) {
             if (!flywheelRunning) {
-                shooter.setShotState(shooter.getShotState());
+                shooter.setPreset(shooter.getPreset());
                 flywheelRunning = true;
             }
             if (shooter.isAtTargetRPM()) {
@@ -420,12 +420,12 @@ public abstract class PrimeTeleOpBase extends LinearOpMode {
 
         telemetry.addLine();
         telemetry.addLine("=== SHOOTER SUBSYSTEM ===");
-        telemetry.addData("Preset", shooter.getShotState().name());
+        telemetry.addData("Preset", shooter.getPreset().name());
         telemetry.addData("Target RPM", shooter.getTargetRPM());
         telemetry.addData("Current RPM", String.format("%.0f", shooter.getCurrentRPM()));
         telemetry.addData("At Target", shooter.isAtTargetRPM() ? "✓ YES" : "✗ NO");
         telemetry.addData("Motor Power", String.format("%.0f%%", shooter.getFlywheelPower() * 100));
-        telemetry.addData("Preset Hood", String.format("%.2f", shooter.getShotState().getHoodPosition()));
+        telemetry.addData("Preset Hood", String.format("%.2f", shooter.getPreset().getHoodPosition()));
         telemetry.addData("Current Hood", String.format("%.2f", shooter.getHoodPosition()));
         telemetry.addData("Sequential Mode", flywheelRunning ? "RUNNING" : "IDLE");
 


### PR DESCRIPTION
## Description
Refactors the shooter subsystem to use more semantically accurate naming. Renames the `ShotState` enum to `ShotPreset` and updates all related methods and variables to reflect that these are preset configurations rather than state representations.

### Changes Made
- Renamed `ShotState` enum to `ShotPreset` in `ShooterSubsystem`
- Renamed `currentShotState` field to `currentPreset`
- Renamed `setShotState()` method to `setPreset()`
- Renamed `getShotState()` method to `getPreset()`
- Updated all call sites in `TeleOpBase` and `BlueLongDriveShoot`
- Updated javadoc comments to reflect the new naming

### Rationale
The enum represents preset shooting configurations (short/medium/long range) rather than dynamic state changes. The new naming is more accurate and improves code clarity for future maintainers.

## Test Plan
No testing needed - this is a straightforward refactoring with no functional changes. All method signatures and behavior remain identical; only names have been updated.

https://claude.ai/code/session_01G44BN2Ypf3neCAfWDTgkGm