### PR TITLE
Refactor IntakeSubsystem to use FTCLib command framework

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/subsystems/IntakeSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/subsystems/IntakeSubsystem.java
@@ -1,376 +1,149 @@
 package org.firstinspires.ftc.teamcode.common.subsystems;
 
+import com.arcrobotics.ftclib.command.SubsystemBase;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.Servo;
 
-/**
- * Intake subsystem for collecting and ejecting game artifacts
- * Uses continuous rotation servos for wheels and position servos for slides
- * Implements state machine pattern for robust control
- */
-public class IntakeSubsystem {
+public class IntakeSubsystem extends SubsystemBase {
 
-    /**
-     * State machine for intake wheel control
-     */
-    public enum WheelState {
-        IDLE,      // Wheels stopped
-        INTAKING,  // Wheels running to intake
-        EJECTING   // Wheels running to eject
-    }
-
-    /**
-     * State machine for intake slide position
-     */
-    public enum SlideState {
-        IN,   // Slides retracted
-        OUT   // Slides extended
-    }
-
-    // Hardware
-    private final Servo intakeWheelLeft;  // Continuous rotation
-    private final Servo intakeWheelRight; // Continuous rotation
-    private final Servo intakeSlideLeft;  // Position servo
-    private final Servo intakeSlideRight; // Position servo
-
-    // Hardware configuration names - hardcoded here!
-    private static final String WHEEL_LEFT_NAME = "leftIntake";
+    // Hardware config names
+    private static final String WHEEL_LEFT_NAME  = "leftIntake";
     private static final String WHEEL_RIGHT_NAME = "rightIntake";
-    private static final String SLIDE_LEFT_NAME = "leftSlide";
+    private static final String SLIDE_LEFT_NAME  = "leftSlide";
     private static final String SLIDE_RIGHT_NAME = "rightSlide";
 
-    // Constants for continuous rotation servos (wheels)
+    // Wheel servo speeds (continuous rotation; position = STOP + speed * 0.5)
     private static final double STOP_POSITION = 0.5;
-    private static final double INTAKE_SPEED = -1.0;   // Full speed intake
-    private static final double EJECT_SPEED = 1.0;   // Full speed eject
+    private static final double INTAKE_SPEED  = -1.0;
+    private static final double EJECT_SPEED   =  1.0;
 
-    // Constants for position servos (slides)
-    private static final double SLIDE_IN_POSITION = 0.0;
+    // Slide servo positions (position servos)
+    private static final double SLIDE_IN_POSITION  = 0.0;
+    private static final double SLIDE_OUT_POSITION = 0.85; // 0.90 caused overheating at full extension
 
-    /*
-    * Optimized position - prevents servo overheating
-    * Previously 0.90 but seemed to be going too far
-    * Testing showed 0.85 provides good extension without strain
-    */
-    private static final double SLIDE_OUT_POSITION = 0.85;
-
-    /*
-    * Automatic slide control constants
-    * Delay before stopping wheels after slides retract
-    * Previously 300, then 1200
-    * Set to 600ms to work with index motor delays
-    */
+    // FINISHING window: slides retract immediately; wheels keep running until this elapses
     private static final long WHEEL_STOP_DELAY_MS = 600;
 
+    public enum Status {
+        IDLE,
+        INTAKING,
+        EJECTING,
+        FINISHING,
+        MANUAL
+    }
 
-    // State tracking
-    private WheelState wheelState = WheelState.IDLE;
-    private SlideState slideState = SlideState.IN;
+    private enum Direction { NONE, FORWARD, REVERSE }
 
-    // Automatic slide control state
-    private boolean autoSlideControlEnabled = true;
-    private boolean delayedWheelStop = false; // True when slides retracted but wheels still running
-    private long slideRetractTime = 0; // Time when slides were retracted (in milliseconds)
+    private final Servo intakeWheelLeft;
+    private final Servo intakeWheelRight;
+    private final Servo intakeSlideLeft;
+    private final Servo intakeSlideRight;
 
+    private Direction wheelDirection = Direction.NONE;
+    private long      stopTimestamp  = 0;
+    private boolean   manualOverride = false;
 
-    /**
-     * Constructor - initializes hardware and sets initial states
-     * @param hardwareMap The hardware map from the OpMode
-     */
     public IntakeSubsystem(HardwareMap hardwareMap) {
-        // Initialize wheel servos (continuous rotation)
-        intakeWheelLeft = hardwareMap.get(Servo.class, WHEEL_LEFT_NAME);
+        intakeWheelLeft  = hardwareMap.get(Servo.class, WHEEL_LEFT_NAME);
         intakeWheelRight = hardwareMap.get(Servo.class, WHEEL_RIGHT_NAME);
-
-        // Initialize slide servos (position)
-        intakeSlideLeft = hardwareMap.get(Servo.class, SLIDE_LEFT_NAME);
+        intakeSlideLeft  = hardwareMap.get(Servo.class, SLIDE_LEFT_NAME);
         intakeSlideRight = hardwareMap.get(Servo.class, SLIDE_RIGHT_NAME);
 
-        // Set direction of left side servos so they mirror right side
         intakeWheelLeft.setDirection(Servo.Direction.FORWARD);
-        intakeSlideLeft.setDirection(Servo.Direction.FORWARD);
-
-        // Reverse right side servos so they mirror left side
         intakeWheelRight.setDirection(Servo.Direction.REVERSE);
+        intakeSlideLeft.setDirection(Servo.Direction.FORWARD);
         intakeSlideRight.setDirection(Servo.Direction.REVERSE);
 
-        // Initialize to safe starting state
-        setWheelState(WheelState.IDLE);
-        setSlideState(SlideState.IN);
+        setWheelHardware(Direction.NONE);
+        setSlidesHardware(false);
     }
 
-    /**
-     * Periodic method called once per scheduler run
-     * Handles automatic slide control based on intake wheel state
-     */
+    @Override
     public void periodic() {
-        if (!autoSlideControlEnabled) {
-            return; // Manual control mode, don't auto-control slides
-        }
-
-        // Automatic slide control logic
-        long currentTime = System.currentTimeMillis();
-
-        if (delayedWheelStop) {
-            // We're in delayed stop mode - wheels running after slides retracted
-            long timeSinceRetract = currentTime - slideRetractTime;
-            if (timeSinceRetract >= WHEEL_STOP_DELAY_MS) {
-                // Delay period is over, actually stop the wheels now
-                wheelState = WheelState.IDLE;
-                updateWheelHardware();
-                delayedWheelStop = false;
-            }
-        } else if (wheelState == WheelState.INTAKING || wheelState == WheelState.EJECTING) {
-            // Intake is active - extend slides immediately
-            if (slideState != SlideState.OUT) {
-                setSlideState(SlideState.OUT);
-            }
+        if (stopTimestamp != 0 &&
+                System.currentTimeMillis() - stopTimestamp >= WHEEL_STOP_DELAY_MS) {
+            wheelDirection = Direction.NONE;
+            setWheelHardware(Direction.NONE);
+            stopTimestamp = 0;
         }
     }
 
-    // ==================== WHEEL STATE MACHINE METHODS ====================
+    // ---- Status -------------------------------------------------------
 
-    /**
-     * Set the wheel state and update hardware accordingly
-     * @param newState The desired wheel state
-     */
-    public void setWheelState(WheelState newState) {
-        wheelState = newState;
-        updateWheelHardware();
+    public Status getStatus() {
+        if (manualOverride)                      return Status.MANUAL;
+        if (stopTimestamp != 0)                  return Status.FINISHING;
+        if (wheelDirection == Direction.FORWARD) return Status.INTAKING;
+        if (wheelDirection == Direction.REVERSE) return Status.EJECTING;
+        return Status.IDLE;
     }
 
-    /**
-     * Get the current wheel state
-     * @return Current wheel state
-     */
-    public WheelState getWheelState() {
-        return wheelState;
+    public boolean isIdle()             { return getStatus() == Status.IDLE; }
+    public boolean isInManualOverride() { return manualOverride; }
+    public boolean isExtended()         { return intakeSlideLeft.getPosition() == SLIDE_OUT_POSITION; }
+
+    public boolean isRunning() {
+        Status s = getStatus();
+        return s == Status.INTAKING || s == Status.EJECTING || s == Status.FINISHING;
     }
 
-    /**
-     * Get wheel state as a string for telemetry
-     * @return State name
-     */
-    public String getWheelStateString() {
-        return wheelState.name();
+    // ---- Commands -----------------------------------------------------
+
+    public void intake() {
+        manualOverride = false;
+        stopTimestamp  = 0;
+        wheelDirection = Direction.FORWARD;
+        setWheelHardware(Direction.FORWARD);
+        setSlidesHardware(true);
     }
 
-    /**
-     * Update wheel servo positions based on current state
-     */
-    private void updateWheelHardware() {
+    public void eject() {
+        manualOverride = false;
+        stopTimestamp  = 0;
+        wheelDirection = Direction.REVERSE;
+        setWheelHardware(Direction.REVERSE);
+        setSlidesHardware(true);
+    }
+
+    public void stop() {
+        if (stopTimestamp != 0) return;
+        manualOverride = false;
+        setSlidesHardware(false);
+        if (wheelDirection != Direction.NONE) {
+            stopTimestamp = System.currentTimeMillis();
+        }
+    }
+
+    public void enableManualOverride()  { manualOverride = true; }
+    public void disableManualOverride() { manualOverride = false; }
+
+    public void extendSlides() {
+        if (!manualOverride) return;
+        setSlidesHardware(true);
+    }
+
+    public void retractSlides() {
+        if (!manualOverride) return;
+        setSlidesHardware(false);
+    }
+
+    // ---- Hardware helpers ---------------------------------------------
+
+    private void setWheelHardware(Direction dir) {
         double speed;
-        switch (wheelState) {
-            case INTAKING:
-                speed = INTAKE_SPEED;
-                break;
-            case EJECTING:
-                speed = EJECT_SPEED;
-                break;
-            case IDLE:
-            default:
-                speed = 0.0;
-                break;
+        switch (dir) {
+            case FORWARD: speed = INTAKE_SPEED; break;
+            case REVERSE: speed = EJECT_SPEED;  break;
+            default:      speed = 0.0;          break;
         }
-        setWheelSpeed(speed);
-    }
-
-    /**
-     * Set the speed of the intake wheel servos
-     * @param speed Speed from -1.0 (eject) to 1.0 (intake), 0.0 is stop
-     */
-    private void setWheelSpeed(double speed) {
-        // Clamp speed to valid range
-        speed = Math.max(-1.0, Math.min(1.0, speed));
-
-        // Convert speed (-1.0 to 1.0) to servo position (0.0 to 1.0)
         double position = STOP_POSITION + (speed * 0.5);
-
-        // Both servos get the same position command
-        // Right servo is reversed in hardware, so it will spin opposite direction
         intakeWheelLeft.setPosition(position);
         intakeWheelRight.setPosition(position);
     }
 
-    // ==================== SLIDE STATE MACHINE METHODS ====================
-
-    /**
-     * Set the slide state and update hardware accordingly
-     * @param newState The desired slide state
-     */
-    public void setSlideState(SlideState newState) {
-        slideState = newState;
-        updateSlideHardware();
-    }
-
-    /**
-     * Get the current slide state
-     * @return Current slide state
-     */
-    public SlideState getSlideState() {
-        return slideState;
-    }
-
-    /**
-     * Get slide state as a string for telemetry
-     * @return State name
-     */
-    public String getSlideStateString() {
-        return slideState.name();
-    }
-
-    /**
-     * Update slide servo positions based on current state
-     */
-    private void updateSlideHardware() {
-        double position;
-        switch (slideState) {
-            case OUT:
-                position = SLIDE_OUT_POSITION;
-                break;
-            case IN:
-            default:
-                position = SLIDE_IN_POSITION;
-                break;
-        }
-        setSlidePosition(position);
-    }
-
-    /**
-     * Set the position of the intake slides
-     * @param position Position from 0.0 (in) to 1.0 (out)
-     */
-    private void setSlidePosition(double position) {
-        // Clamp position to valid range
-        position = Math.max(0.0, Math.min(1.0, position));
-
-        // Both servos get the same position command
-        // Right servo is reversed in hardware, so it will mirror left side
+    private void setSlidesHardware(boolean extended) {
+        double position = extended ? SLIDE_OUT_POSITION : SLIDE_IN_POSITION;
         intakeSlideLeft.setPosition(position);
         intakeSlideRight.setPosition(position);
-    }
-
-    // ==================== LEGACY COMPATIBILITY METHODS ====================
-    // These maintain backward compatibility with existing teleop code
-
-    /**
-     * Stop the intake wheels
-     * If auto-control is enabled, slides retract immediately and wheels continue for 300ms
-     */
-    public void stop() {
-        // If we're already in delayed stop mode, don't reset the timer
-        if (delayedWheelStop) {
-            return; // Let periodic() complete the delayed stop
-        }
-
-        if (autoSlideControlEnabled && (wheelState == WheelState.INTAKING || wheelState == WheelState.EJECTING)) {
-            // Retract slides immediately
-            setSlideState(SlideState.IN);
-
-            // Enter delayed stop mode - wheels will keep running for 300ms
-            delayedWheelStop = true;
-            slideRetractTime = System.currentTimeMillis();
-
-            // Don't change wheel state yet - let periodic() handle it after delay
-        } else {
-            // Not in auto mode or already idle - just stop normally
-            setWheelState(WheelState.IDLE);
-            delayedWheelStop = false;
-        }
-    }
-
-    /**
-     * Run intake to collect artifacts at full speed
-     */
-    public void intakeArtifact() {
-        delayedWheelStop = false; // Cancel any delayed stop
-        setWheelState(WheelState.INTAKING);
-    }
-
-    /**
-     * Run intake in reverse to eject artifacts at full speed
-     */
-    public void ejectArtifact() {
-        delayedWheelStop = false; // Cancel any delayed stop
-        setWheelState(WheelState.EJECTING);
-    }
-
-    /**
-     * Run intake to collect at a specific speed (legacy method)
-     * @param speed Speed from 0.0 to 1.0
-     */
-    public void intakeArtifact(double speed) {
-        setWheelState(WheelState.INTAKING);
-        // Note: Custom speed not supported in state machine version
-        // Always uses INTAKE_SPEED constant
-    }
-
-    /**
-     * Run intake in reverse at a specific speed (legacy method)
-     * @param speed Speed from 0.0 to 1.0
-     */
-    public void ejectArtifact(double speed) {
-        setWheelState(WheelState.EJECTING);
-        // Note: Custom speed not supported in state machine version
-        // Always uses EJECT_SPEED constant
-    }
-
-    // ==================== AUTOMATIC SLIDE CONTROL METHODS ====================
-
-    /**
-     * Enable automatic slide control (slides extend/retract with intake)
-     */
-    public void enableAutoSlideControl() {
-        autoSlideControlEnabled = true;
-    }
-
-    /**
-     * Disable automatic slide control (manual slide control via setSlideState)
-     */
-    public void disableAutoSlideControl() {
-        autoSlideControlEnabled = false;
-    }
-
-    /**
-     * Check if automatic slide control is enabled
-     * @return true if auto control is enabled
-     */
-    public boolean isAutoSlideControlEnabled() {
-        return autoSlideControlEnabled;
-    }
-
-    // ==================== TELEMETRY HELPER METHODS ====================
-
-    /**
-     * Get the current wheel servo position (raw value 0.0-1.0)
-     * @return Current position
-     */
-    public double getWheelPosition() {
-        return intakeWheelLeft.getPosition();
-    }
-
-    /**
-     * Get the current commanded wheel speed (-1.0 to 1.0)
-     * @return Current speed
-     */
-    public double getSpeed() {
-        double position = intakeWheelLeft.getPosition();
-        return (position - STOP_POSITION) * 2.0;
-    }
-
-    /**
-     * Get the current position of the intake slides
-     * @return Current position (0.0 = in, 1.0 = out)
-     */
-    public double getSlidePosition() {
-        return intakeSlideLeft.getPosition();
-    }
-
-    /**
-     * Legacy compatibility method
-     * @return Current wheel position
-     */
-    public double getPosition() {
-        return getWheelPosition();
     }
 }


### PR DESCRIPTION
## Description

Refactored `IntakeSubsystem` to extend `SubsystemBase` from FTCLib's command framework, replacing the previous state machine implementation with a simpler, more maintainable design.

### Key Changes

- **Framework Integration**: Now extends `SubsystemBase` for compatibility with FTCLib command-based architecture
- **Simplified State Management**: Replaced `WheelState` and `SlideState` enums with a single `Status` enum and internal `Direction` tracking
- **Cleaner API**: 
  - Consolidated wheel control into `intake()`, `eject()`, and `stop()` methods
  - Added `enableManualOverride()` / `disableManualOverride()` for manual slide control
  - Removed legacy overloaded methods that accepted custom speeds
- **Improved Readability**: Reduced code from 376 to 149 lines by eliminating redundant state machine boilerplate
- **Preserved Behavior**: 
  - Automatic slide extension/retraction during intake/eject operations
  - 600ms wheel stop delay after slides retract (prevents servo strain)
  - Manual override capability for slide positioning

### Removed

- `WheelState` and `SlideState` enums
- `getWheelState()`, `getSlideState()`, and their string variants
- `setWheelState()`, `setSlideState()` public methods
- `intakeArtifact()` and `ejectArtifact()` overloads with custom speed parameters
- `enableAutoSlideControl()` / `disableAutoSlideControl()` (auto-control is now always on)
- Telemetry helper methods (`getWheelPosition()`, `getSpeed()`, `getSlidePosition()`, `getPosition()`)

### Added

- `getStatus()` method returning unified `Status` enum
- `isIdle()`, `isRunning()`, `isExtended()`, `isInManualOverride()` convenience methods
- `extendSlides()` / `retractSlides()` for manual override mode

## Test Plan

Verify intake/eject operations work correctly in teleop:
- Intake extends slides and runs wheels forward
- Eject extends slides and runs wheels reverse
- Stop retracts slides and stops wheels after 600ms delay
- Manual override allows independent slide control

https://claude.ai/code/session_019sCqw5jA7s7jvUF9p3A5MA