### PR TITLE
Add IntakeCommand for intake subsystem control

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/commands/IntakeCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/commands/IntakeCommand.java
@@ -1,0 +1,62 @@
+package org.firstinspires.ftc.teamcode.common.commands;
+
+import com.arcrobotics.ftclib.command.CommandBase;
+
+import org.firstinspires.ftc.teamcode.common.subsystems.IntakeSubsystem;
+
+/**
+ * Runs the intake until interrupted.
+ *
+ * <p>Lifecycle:
+ * <ol>
+ *   <li>{@link #initialize()} calls {@link IntakeSubsystem#intake()}, which starts the wheels
+ *       and extends the slides.</li>
+ *   <li>{@link #execute()} does nothing; {@link IntakeSubsystem#periodic()} handles
+ *       auto-coupling (extend/retract) and the {@code FINISHING} stop-delay window.</li>
+ *   <li>{@link #end(boolean)} calls {@link IntakeSubsystem#stop()}, which retracts the slides
+ *       and arms the {@code FINISHING} timer. The command returns immediately; the subsystem
+ *       transitions through {@code FINISHING} on its own without blocking the command.</li>
+ * </ol>
+ *
+ * <p>{@link #isFinished()} always returns {@code false}: this command is intended for a
+ * {@code whileTrue} binding and is ended by the trigger when the button is released, not
+ * by its own termination condition.
+ *
+ * <p>Releasing the button does <em>not</em> block until the intake has fully stopped.
+ * {@code end} returns immediately; the subsystem's {@code periodic} clears the
+ * {@code FINISHING} state after the stop-delay window elapses.
+ *
+ * <p>Intended binding:
+ * <pre>
+ *   driverGamepad.getGamepadButton(GamepadKeys.Button.RIGHT_BUMPER)
+ *       .whileTrue(new IntakeCommand(intakeSubsystem));
+ * </pre>
+ */
+public class IntakeCommand extends CommandBase {
+
+    private final IntakeSubsystem intake;
+
+    public IntakeCommand(IntakeSubsystem intake) {
+        this.intake = intake;
+        addRequirements(intake);
+    }
+
+    @Override
+    public void initialize() {
+        intake.intake();
+    }
+
+    @Override
+    public void execute() {
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        intake.stop();
+    }
+}


### PR DESCRIPTION
## Description
Adds a new `IntakeCommand` class that manages intake subsystem operations through FTCLib's command-based framework.

## Changes
- Created `IntakeCommand` extending `CommandBase` to handle intake wheel and slide control
- Command lifecycle:
  - `initialize()`: Starts intake wheels and extends slides via `IntakeSubsystem#intake()`
  - `execute()`: No-op; subsystem's `periodic()` handles auto-coupling and stop-delay logic
  - `end()`: Retracts slides and arms the `FINISHING` timer via `IntakeSubsystem#stop()`
- `isFinished()` always returns `false` for use with `whileTrue` trigger bindings
- Non-blocking design: button release doesn't wait for intake to fully stop; subsystem handles state transitions independently

## Intended Usage
```java
driverGamepad.getGamepadButton(GamepadKeys.Button.RIGHT_BUMPER)
    .whileTrue(new IntakeCommand(intakeSubsystem));
```

## Test Plan
Verify intake command integrates correctly with the subsystem's periodic state machine and responds appropriately to button press/release cycles during driver-controlled testing.

https://claude.ai/code/session_01Qj3eEMQnJHF36KLHgULosu