### PR TITLE
Add DefaultDriveCommand for mecanum drive teleoperation

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/commands/DefaultDriveCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/commands/DefaultDriveCommand.java
@@ -1,0 +1,77 @@
+package org.firstinspires.ftc.teamcode.common.commands;
+
+import com.arcrobotics.ftclib.command.CommandBase;
+import com.arcrobotics.ftclib.gamepad.GamepadEx;
+
+import org.firstinspires.ftc.teamcode.common.subsystems.MecanumDriveSubsystem;
+
+/**
+ * Default command for {@link MecanumDriveSubsystem}.
+ *
+ * <p>A <em>default command</em> is the command the scheduler runs on a subsystem whenever no
+ * other command is using it. It is registered via
+ * {@code drive.setDefaultCommand(new DefaultDriveCommand(drive, driverGamepad))} in the TeleOp
+ * setup method and starts running automatically at the beginning of the OpMode.
+ *
+ * <p>Lifecycle relative to other drive commands:
+ * <ul>
+ *   <li>When an auto-align (or any other command that requires the drive subsystem) is triggered,
+ *       the scheduler suspends this command by calling {@link #end(boolean)} with
+ *       {@code interrupted = true}, then hands control to the new command.</li>
+ *   <li>When that other command finishes or is cancelled, the scheduler automatically restarts
+ *       this default command from {@link #initialize()}. The driver regains stick control without
+ *       any explicit re-binding. This automatic hand-back is the defining property of the default
+ *       command pattern.</li>
+ * </ul>
+ *
+ * <p>Responsibilities of this class:
+ * <ul>
+ *   <li>Read the driver gamepad sticks each tick.</li>
+ *   <li>Forward the raw values to {@link MecanumDriveSubsystem#drive(double, double, double)}.</li>
+ *   <li>Call {@link MecanumDriveSubsystem#stop()} when interrupted.</li>
+ * </ul>
+ *
+ * <p>Responsibilities that live <em>elsewhere</em>:
+ * <ul>
+ *   <li><strong>Deadzone, sensitivity curve, speed multipliers, field-centric rotation, mecanum
+ *       mixing:</strong> all handled inside {@link MecanumDriveSubsystem#periodic()}. This command
+ *       passes raw stick values straight through — no transformations here.</li>
+ *   <li><strong>Heading mode toggle, speed mode toggle, heading reset, base-speed adjustment,
+ *       emergency stop:</strong> bound as separate {@code InstantCommand} / {@code RunCommand}
+ *       trigger bindings in the TeleOp class. They are not handled here.</li>
+ * </ul>
+ */
+public class DefaultDriveCommand extends CommandBase {
+
+    private final MecanumDriveSubsystem drive;
+    private final GamepadEx driverGamepad;
+
+    public DefaultDriveCommand(MecanumDriveSubsystem drive, GamepadEx driverGamepad) {
+        this.drive = drive;
+        this.driverGamepad = driverGamepad;
+        addRequirements(drive);
+    }
+
+    @Override
+    public void initialize() {
+        // Default commands typically have no one-time setup; the subsystem is already running.
+    }
+
+    @Override
+    public void execute() {
+        double forward = -driverGamepad.getLeftY();  // gamepad Y is inverted: up = negative
+        double strafe  =  driverGamepad.getLeftX();
+        double rotate  =  driverGamepad.getRightX();
+        drive.drive(forward, strafe, rotate);
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        drive.stop();
+    }
+}


### PR DESCRIPTION
## Description
Adds `DefaultDriveCommand`, a command-based controller for the mecanum drive subsystem during teleoperation. This command implements the FTCLib default command pattern, continuously reading driver gamepad input and forwarding it to the drive subsystem.

## Key Features
- Reads left stick (forward/strafe) and right stick (rotation) inputs from the driver gamepad
- Inverts Y-axis to match standard gamepad conventions (up = positive forward)
- Automatically suspends when other commands (e.g., auto-align) require the drive subsystem
- Automatically resumes when higher-priority commands complete, restoring driver control without re-binding
- Calls `stop()` on the drive subsystem when interrupted

## Design Notes
- Raw stick values are passed directly to the drive subsystem; all processing (deadzone, sensitivity curves, field-centric rotation, speed multipliers) is handled in `MecanumDriveSubsystem.periodic()`
- Other driver controls (heading mode toggle, speed mode toggle, emergency stop, etc.) are bound as separate trigger commands in the TeleOp class
- Comprehensive Javadoc explains the default command lifecycle and responsibility separation

## Test Plan
No testing needed. This is a straightforward command implementation that will be validated through integration testing during teleoperation setup.

https://claude.ai/code/session_019JVQ2Hy7dfdZb4Zbm2xkXA