### PR TITLE
Fix class naming and import issues in TeleOp classes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/teleop/TeleOpBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/teleop/TeleOpBase.java
@@ -9,7 +9,7 @@ import org.firstinspires.ftc.teamcode.common.subsystems.IndexSubsystem;
 import org.firstinspires.ftc.teamcode.common.subsystems.ShooterSubsystem;
 import org.firstinspires.ftc.teamcode.common.subsystems.PinpointOdometrySubsystem;
 
-public abstract class PrimeTeleOpBase extends LinearOpMode {
+public abstract class TeleOpBase extends LinearOpMode {
 
     /* ========================================
      * SUBSYSTEMS

--- a/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/TeleOp.java
+++ b/TeamCode/src/team11940/java/org/firstinspires/ftc/teamcode/team11940/TeleOp.java
@@ -1,10 +1,9 @@
 package org.firstinspires.ftc.teamcode.team11940;
 
-import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.teamcode.common.config.RobotConfig;
 import org.firstinspires.ftc.teamcode.common.teleop.TeleOpBase;
 
-@TeleOp(name = "Team 11940 TeleOp", group = "TeleOp")
+@com.qualcomm.robotcore.eventloop.opmode.TeleOp(name = "Team 11940 TeleOp", group = "TeleOp")
 public class TeleOp extends TeleOpBase {
     @Override
     protected RobotConfig getRobotConfig() { return new Team11940Config(); }

--- a/TeamCode/src/team22091/java/org/firstinspires/ftc/teamcode/team22091/TeleOp.java
+++ b/TeamCode/src/team22091/java/org/firstinspires/ftc/teamcode/team22091/TeleOp.java
@@ -1,10 +1,9 @@
 package org.firstinspires.ftc.teamcode.team22091;
 
-import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.teamcode.common.config.RobotConfig;
 import org.firstinspires.ftc.teamcode.common.teleop.TeleOpBase;
 
-@TeleOp(name = "Team 22091 TeleOp", group = "TeleOp")
+@com.qualcomm.robotcore.eventloop.opmode.TeleOp(name = "Team 22091 TeleOp", group = "TeleOp")
 public class TeleOp extends TeleOpBase {
     @Override
     protected RobotConfig getRobotConfig() { return new Team22091Config(); }


### PR DESCRIPTION
## Description

This PR fixes two issues in the TeleOp implementation:

1. **Class naming bug in TeleOpBase**: The abstract class was incorrectly named `PrimeTeleOpBase` instead of `TeleOpBase`, causing a mismatch with the class declaration and inheritance chain.

2. **Import statement refactoring**: Removed unused wildcard imports of `com.qualcomm.robotcore.eventloop.opmode.TeleOp` from team-specific TeleOp classes and replaced with fully qualified annotation references. This eliminates naming conflicts since the team classes themselves are named `TeleOp`.

## Changes

- Fixed class name in `TeleOpBase.java` from `PrimeTeleOpBase` to `TeleOpBase`
- Removed `import com.qualcomm.robotcore.eventloop.opmode.TeleOp` from `team11940/TeleOp.java`
- Removed `import com.qualcomm.robotcore.eventloop.opmode.TeleOp` from `team22091/TeleOp.java`
- Updated annotations to use fully qualified names: `@com.qualcomm.robotcore.eventloop.opmode.TeleOp`

## Test Plan

N/A - These are straightforward naming and import fixes that resolve compilation issues.

https://claude.ai/code/session_01GFDfeToGbU5PKfCKAAy3Jn