### PR TITLE
Session B: fill in bindCommands() with all trigger bindings

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/teleop/TeleOpBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/common/teleop/TeleOpBase.java
@@ -1,10 +1,17 @@
 package org.firstinspires.ftc.teamcode.common.teleop;
 
 import com.arcrobotics.ftclib.command.CommandOpMode;
+import com.arcrobotics.ftclib.command.InstantCommand;
+import com.arcrobotics.ftclib.command.RunCommand;
+import com.arcrobotics.ftclib.command.button.Trigger;
 import com.arcrobotics.ftclib.gamepad.GamepadEx;
+import com.arcrobotics.ftclib.gamepad.GamepadKeys;
 
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.common.commands.DefaultDriveCommand;
+import org.firstinspires.ftc.teamcode.common.commands.EjectCommand;
+import org.firstinspires.ftc.teamcode.common.commands.IntakeCommand;
+import org.firstinspires.ftc.teamcode.common.commands.ShootCommand;
 import org.firstinspires.ftc.teamcode.common.config.RobotConfig;
 import org.firstinspires.ftc.teamcode.common.helpers.Limelight;
 import org.firstinspires.ftc.teamcode.common.helpers.PinpointOdometry;
@@ -12,6 +19,8 @@ import org.firstinspires.ftc.teamcode.common.subsystems.IndexSubsystem;
 import org.firstinspires.ftc.teamcode.common.subsystems.IntakeSubsystem;
 import org.firstinspires.ftc.teamcode.common.subsystems.MecanumDriveSubsystem;
 import org.firstinspires.ftc.teamcode.common.subsystems.ShooterSubsystem;
+
+import static org.firstinspires.ftc.teamcode.common.subsystems.MecanumDriveSubsystem.SpeedMode;
 
 /**
  * Abstract base for all team-specific TeleOp OpModes.
@@ -157,7 +166,79 @@ public abstract class TeleOpBase extends CommandOpMode {
      * safely reference any field on this class.
      */
     protected void bindCommands() {
-        // Session B: trigger bindings go here.
+
+        // ---- Drive: precision speed mode ------------------------------------
+        // Left trigger held → PRECISION; releasing returns to NORMAL.
+        // whileFalse ensures NORMAL is restored even if the trigger isn't pressed at startup.
+        new Trigger(() -> driverGamepad.getLeftTrigger() > 0.1)
+                .whileTrue(new RunCommand(() -> drive.setSpeedMode(SpeedMode.PRECISION), drive))
+                .whileFalse(new RunCommand(() -> drive.setSpeedMode(SpeedMode.NORMAL), drive));
+
+        // ---- Intake / eject -------------------------------------------------
+        // Left bumper held → run intake wheels forward + extend slides.
+        driverGamepad.getGamepadButton(GamepadKeys.Button.LEFT_BUMPER)
+                .whileTrue(new IntakeCommand(intake));
+
+        // X held → run intake wheels in reverse (eject).
+        driverGamepad.getGamepadButton(GamepadKeys.Button.X)
+                .whileTrue(new EjectCommand(intake));
+
+        // ---- Shooting -------------------------------------------------------
+        // Right bumper held → spin up + feed when at speed.
+        driverGamepad.getGamepadButton(GamepadKeys.Button.RIGHT_BUMPER)
+                .whileTrue(new ShootCommand(shooter, index));
+
+        // Right trigger pressed → same shoot sequence (separate binding; easy to reassign later).
+        new Trigger(() -> driverGamepad.getRightTrigger() > 0.1)
+                .whileTrue(new ShootCommand(shooter, index));
+
+        // ---- Preset selection -----------------------------------------------
+        // A → SHORT_RANGE preset (2 200 RPM, hood 0.30).
+        driverGamepad.getGamepadButton(GamepadKeys.Button.A)
+                .onTrue(new InstantCommand(
+                        () -> shooter.setPreset(ShooterSubsystem.ShotPreset.SHORT_RANGE), shooter));
+
+        // B → MEDIUM_RANGE preset (2 500 RPM, hood 0.60).
+        driverGamepad.getGamepadButton(GamepadKeys.Button.B)
+                .onTrue(new InstantCommand(
+                        () -> shooter.setPreset(ShooterSubsystem.ShotPreset.MEDIUM_RANGE), shooter));
+
+        // Y → LONG_RANGE preset (2 800 RPM, hood 0.60).
+        driverGamepad.getGamepadButton(GamepadKeys.Button.Y)
+                .onTrue(new InstantCommand(
+                        () -> shooter.setPreset(ShooterSubsystem.ShotPreset.LONG_RANGE), shooter));
+
+        // ---- Heading / drive mode -------------------------------------------
+        // BACK → switch to field-centric heading mode.
+        driverGamepad.getGamepadButton(GamepadKeys.Button.BACK)
+                .onTrue(new InstantCommand(
+                        () -> drive.setHeadingMode(MecanumDriveSubsystem.HeadingMode.FIELD_CENTRIC),
+                        drive));
+
+        // GUIDE → zero the field-centric heading reference.
+        driverGamepad.getGamepadButton(GamepadKeys.Button.GUIDE)
+                .onTrue(new InstantCommand(() -> drive.resetHeading(), drive));
+
+        // ---- Configuration adjustments --------------------------------------
+        // D-pad up/down: base speed ±0.05, clamped [0.1, 1.0].
+        driverGamepad.getGamepadButton(GamepadKeys.Button.DPAD_UP)
+                .onTrue(new InstantCommand(
+                        () -> drive.setBaseSpeed(Math.min(1.0, drive.getBaseSpeed() + 0.05)), drive));
+
+        driverGamepad.getGamepadButton(GamepadKeys.Button.DPAD_DOWN)
+                .onTrue(new InstantCommand(
+                        () -> drive.setBaseSpeed(Math.max(0.1, drive.getBaseSpeed() - 0.05)), drive));
+
+        // D-pad right/left: sensitivity ±0.1, clamped [0.5, 2.0].
+        driverGamepad.getGamepadButton(GamepadKeys.Button.DPAD_RIGHT)
+                .onTrue(new InstantCommand(
+                        () -> drive.setSensitivity(Math.min(2.0, drive.getSensitivity() + 0.1)),
+                        drive));
+
+        driverGamepad.getGamepadButton(GamepadKeys.Button.DPAD_LEFT)
+                .onTrue(new InstantCommand(
+                        () -> drive.setSensitivity(Math.max(0.5, drive.getSensitivity() - 0.1)),
+                        drive));
     }
 
     // ========================================================================


### PR DESCRIPTION
All 14 binding points wired in TeleOpBase.bindCommands():
- Left trigger: PRECISION speed mode (whileTrue/whileFalse RunCommand)
- Left bumper: IntakeCommand (whileTrue)
- X: EjectCommand (whileTrue)
- Right bumper: ShootCommand (whileTrue)
- Right trigger: ShootCommand (separate binding, easy to reassign)
- A/B/Y: SHORT/MEDIUM/LONG_RANGE preset InstantCommands (onTrue)
- BACK: setHeadingMode FIELD_CENTRIC (onTrue)
- GUIDE: resetHeading (onTrue)
- DPAD UP/DOWN: baseSpeed ±0.05 clamped [0.1, 1.0] (onTrue)
- DPAD RIGHT/LEFT: sensitivity ±0.1 clamped [0.5, 2.0] (onTrue)

New imports: InstantCommand, RunCommand, Trigger, GamepadKeys, EjectCommand, IntakeCommand, ShootCommand, static SpeedMode.

Only bindCommands() and the imports block modified. No other method touched. No jam-clear bindings. No gamepad2. START left unbound (reserved per driver control guide).

https://claude.ai/code/session_01FHtpNjwVvCXVP3aBLdN9qh

Before issuing a pull request, please see the contributing page.
